### PR TITLE
Add support to skipped notifications (from, to)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ This script provies a HTTP endpoint `/hubot/jenkinsnotify` which is designed to 
 
 ## Environment variables
 
-### `HUBOT_JENKINS_NOTIFY_ROOMS` 
+### `HUBOT_JENKINS_NOTIFY_ROOMS`
 Contains a JSON object of key and values, the key is the url of the Jenkins server and the value is the room which message should be sent from.
 ```
-HUBOT_JENKINS_NOTIFY_ROOMS="{"https://ci.example.org": "#developers"}"
+HUBOT_JENKINS_NOTIFY_ROOMS="{\"https://ci.example.org\": \"#developers\"}"
+```
+
+### `HUBOT_JENKINS_SKIP_NOTIFICATION`
+Contains a JSON array of pairs containing state changes (before after) that should not lead to notification.
+```
+HUBOT_JENKINS_SKIP_NOTIFICATION="[ [ \"SUCCESS\", \"UNSTABLE\" ], [ \"FAILURE\", \"ABORTED\" ] ]"
 ```
 
 ## Notifying when state hasn't changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-jenkins-notify-statuschanges",
   "description": "Notify if jenkins job status changes",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Dan Poltawski <dan@moodle.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts",


### PR DESCRIPTION
With HUBOT_JENKINS_SKIP_NOTIFICATION it's possible to specify
pairs of statuses (from , to) not leading to any notification.