### PR TITLE
Verify the job has been executed before trying to access to lastBuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-jenkins-notify-statuschanges",
   "description": "Notify if jenkins job status changes",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Dan Poltawski <dan@moodle.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts",

--- a/src/jenkins-notify-statuschanges.coffee
+++ b/src/jenkins-notify-statuschanges.coffee
@@ -35,7 +35,7 @@ getBuildStatusFromServer = (robot, server, roomid) ->
             return
         try
             data = JSON.parse(body)
-            failedjobs = (job for job in data.jobs when job.lastBuild.result != "SUCCESS")
+            failedjobs = (job for job in data.jobs when job.lastBuild != null and job.lastBuild.result != "SUCCESS")
         catch
             failedjobs = []
 


### PR DESCRIPTION
Since long ago we had detected that, on startup, the bot was missing the
status from a couple of our ci servers. After tracing the problem down,
it was caused by some jobs in those servers that never had been run,
hence their lastBuild was null.

This simply adds a check to ensure that some build has happened.

![image](https://user-images.githubusercontent.com/167147/52167337-e7e94180-2719-11e9-9198-ca431d33ad28.png)
